### PR TITLE
Make sure Pumpjacks Mk2 recipe correctly uses Pipe Mk2

### DIFF
--- a/info.json
+++ b/info.json
@@ -7,5 +7,9 @@
   "author": "jimmyjon711 (Original Author: Nath Gamer)",
   "homepage": "",
   "description": "",
-  "dependencies": ["base >= 0.16.20", "FactorioExtended-Plus-Core >= 0.1.2"]
+  "dependencies": [
+    "base >= 0.16.20",
+    "FactorioExtended-Plus-Core >= 0.1.2",
+    "?FactorioExtended-Plus-Transport >= 0.1.6"
+  ]
 }


### PR DESCRIPTION
Changes the load order so that Pipe Mk2 from the Transport mod is available
when the pumpjack code is executed.

The code in question that is currently not being called is [recipe-machine.lua#L205-L208](https://github.com/jimmyjon711/FactorioExtended-Plus-Machines/blob/8f0004254c6ac9d6308cff9aecb8620efbc278c8/prototypes/recipe/recipe-machine.lua#L205-L208)

This depends on jimmyjon711/FactorioExtended-Plus-Core#2 to be merged first, because it will otherwise cause crashes.