### PR TITLE
icons showing up as wrong size in upgrade planner

### DIFF
--- a/prototypes/entity/assembling-machine.lua
+++ b/prototypes/entity/assembling-machine.lua
@@ -9,9 +9,9 @@ data.raw["assembling-machine"]["assembling-machine-3"].next_upgrade = "assemblin
 
 local am4 = table.deepcopy(data.raw["assembling-machine"]["assembling-machine-3"])
 am4.name = "assembling-machine-4"
--- am4.icon = "__FactorioExtended-Plus-Machines__/graphics/icons/" .. am4.name .. ".png"
--- am4.icon_size = 32
--- am4.icon_mipmaps = nil
+am4.icon = "__FactorioExtended-Plus-Machines__/graphics/icons/" .. am4.name .. ".png"
+am4.icon_size = 64
+am4.icon_mipmaps = 4
 am4.max_health = 450
 am4.minable.result = am4.name
 am4.next_upgrade = "assembling-machine-5"
@@ -31,9 +31,9 @@ end
 
 local am5 = table.deepcopy(data.raw["assembling-machine"]["assembling-machine-3"])
 am5.name = "assembling-machine-5"
--- am5.icon = "__FactorioExtended-Plus-Machines__/graphics/icons/" .. am5.name .. ".png"
--- am5.icon_size = 32
--- am5.icon_mipmaps = nil
+am5.icon = "__FactorioExtended-Plus-Machines__/graphics/icons/" .. am5.name .. ".png"
+am5.icon_size = 64
+am5.icon_mipmaps = 4
 am5.max_health = 500
 am5.minable.result = am5.name
 am5.next_upgrade = nil

--- a/prototypes/entity/centrifuge.lua
+++ b/prototypes/entity/centrifuge.lua
@@ -1,3 +1,5 @@
+local Constant = require("constant")
+
 -- centrifuge                                       mk1         mk2         mk3
 -- max_health                                       350         400         450
 -- crafting_speed                                   1           1.5         3
@@ -14,9 +16,7 @@ data.raw["assembling-machine"]["centrifuge"].next_upgrade = "centrifuge-mk2"
 
 local c2 = table.deepcopy(data.raw["assembling-machine"]["centrifuge"])
 c2.name = "centrifuge-mk2"
--- c2.icon = "__FactorioExtended-Plus-Machines__/graphics/icons/" .. c2.name .. ".png"
--- c2.icon_size = 32
--- c2.icon_mipmaps = nil
+c2.icons = {{icon = c2.icon, icon_size = c2.icon_size, icon_mipmaps = c2.icon_mipmaps, tint = Constant.green_tint}}
 c2.max_health = 400
 c2.minable.result = c2.name
 c2.next_upgrade = "centrifuge-mk3"
@@ -46,9 +46,7 @@ end
 local c3 = table.deepcopy(data.raw["assembling-machine"]["centrifuge"])
 c3.name = "centrifuge-mk3"
 c3.next_upgrade = nil
--- c3.icon = "__FactorioExtended-Plus-Machines__/graphics/icons/" .. c3.name .. ".png"
--- c3.icon_size = 32
--- c3.icon_mipmaps = nil
+c3.icons = {{icon = c3.icon, icon_size = c3.icon_size, icon_mipmaps = c3.icon_mipmaps, tint = Constant.blue_tint}}
 c3.max_health = 450
 c3.minable.result = c3.name
 c3.crafting_speed = 3

--- a/prototypes/entity/chemical-plant.lua
+++ b/prototypes/entity/chemical-plant.lua
@@ -14,9 +14,9 @@ data.raw["assembling-machine"]["chemical-plant"].next_upgrade = "chemical-plant-
 
 local cp2 = table.deepcopy(data.raw["assembling-machine"]["chemical-plant"])
 cp2.name = "chemical-plant-mk2"
--- cp2.icon = "__FactorioExtended-Plus-Machines__/graphics/icons/" .. cp2.name .. ".png"
--- cp2.icon_size = 32
--- cp2.icon_mipmaps = nil
+cp2.icon = "__FactorioExtended-Plus-Machines__/graphics/icons/" .. cp2.name .. ".png"
+cp2.icon_size = 64
+cp2.icon_mipmaps = 4
 cp2.max_health = 600
 cp2.minable.result = cp2.name
 cp2.next_upgrade = "chemical-plant-mk3"
@@ -32,9 +32,9 @@ end
 
 local cp3 = table.deepcopy(data.raw["assembling-machine"]["chemical-plant"])
 cp3.name = "chemical-plant-mk3"
--- cp3.icon = "__FactorioExtended-Plus-Machines__/graphics/icons/" .. cp3.name .. ".png"
--- cp3.icon_size = 32
--- cp3.icon_mipmaps = nil
+cp3.icon = "__FactorioExtended-Plus-Machines__/graphics/icons/" .. cp3.name .. ".png"
+cp3.icon_size = 64
+cp3.icon_mipmaps = 4
 cp3.max_health = 900
 cp3.minable.result = cp3.name
 cp3.next_upgrade = nil

--- a/prototypes/entity/electric-furnace.lua
+++ b/prototypes/entity/electric-furnace.lua
@@ -14,9 +14,9 @@ data.raw["furnace"]["electric-furnace"].next_upgrade = "electric-furnace-mk2"
 
 local furnace2 = table.deepcopy(data.raw["furnace"]["electric-furnace"])
 furnace2.name = "electric-furnace-mk2"
--- furnace2.icon = "__FactorioExtended-Plus-Machines__/graphics/icons/electric-furnace-mk2.png"
--- furnace2.icon_size = 32
--- furnace2.icon_mipmaps = nil
+furnace2.icon = "__FactorioExtended-Plus-Machines__/graphics/icons/electric-furnace-mk2.png"
+furnace2.icon_size = 64
+furnace2.icon_mipmaps = 4
 furnace2.minable.result = furnace2.name
 furnace2.max_health = 400
 furnace2.module_specification.module_slots = 4
@@ -29,9 +29,9 @@ furnace2.animation.layers[1].hr_version.filename = "__FactorioExtended-Plus-Mach
 
 local furnace3 = table.deepcopy(data.raw["furnace"]["electric-furnace"])
 furnace3.name = "electric-furnace-mk3"
--- furnace3.icon = "__FactorioExtended-Plus-Machines__/graphics/icons/electric-furnace-mk3.png"
--- furnace3.icon_size = 32
--- furnace3.icon_mipmaps = nil
+furnace3.icon = "__FactorioExtended-Plus-Machines__/graphics/icons/electric-furnace-mk3.png"
+furnace3.icon_size = 64
+furnace3.icon_mipmaps = 4
 furnace3.minable.result = furnace3.name
 furnace3.max_health = 450
 furnace3.module_specification.module_slots = 4


### PR DESCRIPTION
When using an upgrade planner,  the entity icons are used.  These have been changed to use the same 64x64 icons that the items use.